### PR TITLE
feat: require main/archive network settings to be overridden together

### DIFF
--- a/pylon_commons/pylon_commons/settings.py
+++ b/pylon_commons/pylon_commons/settings.py
@@ -27,10 +27,10 @@ def _validate_paired_settings_overridden_together(
     env_prefix: str,
 ) -> None:
     """
-    Ensure each main/archive network pair is either both left at its default or both set explicitly.
+    Ensure each setting pair is either both left at its default or both set explicitly.
 
     A pair with exactly one member provided is rejected, because silently mixing an overridden
-    network with a defaulted counterpart is an easy and dangerous misconfiguration. Repeating the
+    value with a defaulted counterpart is an easy and dangerous misconfiguration. Repeating the
     default value is allowed, as long as it is provided explicitly.
 
     Raises:
@@ -44,8 +44,7 @@ def _validate_paired_settings_overridden_together(
         provided, missing = (main_field, archive_field) if main_set else (archive_field, main_field)
         raise ValueError(
             f"{env_prefix}{provided.upper()} was overridden but {env_prefix}{missing.upper()} was left "
-            f"at its default. When overriding one network you must set both explicitly (you may repeat "
-            f"the default value, but it must be explicit)."
+            f"at its default. Set both explicitly (you may repeat the default value, but it must be explicit)."
         )
 
 

--- a/pylon_commons/pylon_commons/settings.py
+++ b/pylon_commons/pylon_commons/settings.py
@@ -90,6 +90,6 @@ class Settings(BaseSettings):
             provided, missing = (main_field, archive_field) if main_set else (archive_field, main_field)
             raise ValueError(
                 f"{env_prefix}{provided.upper()} was overridden but {env_prefix}{missing.upper()} was left "
-                f"at its default. Set both explicitly (you may repeat the default value, but it must be explicit)."
+                "at its default. Set both explicitly."
             )
         return self

--- a/pylon_commons/pylon_commons/settings.py
+++ b/pylon_commons/pylon_commons/settings.py
@@ -1,6 +1,5 @@
 import os
-from collections.abc import Iterable
-from typing import Self
+from typing import ClassVar, Self
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -13,39 +12,6 @@ from .types import (
 from .types import evm as evm_types
 
 ENV_FILE = os.environ.get("PYLON_ENV_FILE", ".env")
-
-# Pairs of (main, archive) network settings that must be overridden together.
-_PAIRED_NETWORK_FIELDS: tuple[tuple[str, str], ...] = (
-    ("bittensor_network", "bittensor_archive_network"),
-    ("evm_rpc_url", "evm_archive_rpc_url"),
-)
-
-
-def _validate_paired_settings_overridden_together(
-    fields_set: set[str],
-    field_pairs: Iterable[tuple[str, str]],
-    env_prefix: str,
-) -> None:
-    """
-    Ensure each setting pair is either both left at its default or both set explicitly.
-
-    A pair with exactly one member provided is rejected, because silently mixing an overridden
-    value with a defaulted counterpart is an easy and dangerous misconfiguration. Repeating the
-    default value is allowed, as long as it is provided explicitly.
-
-    Raises:
-        ValueError: If exactly one member of a pair was provided.
-    """
-    for main_field, archive_field in field_pairs:
-        main_set = main_field in fields_set
-        archive_set = archive_field in fields_set
-        if main_set == archive_set:
-            continue
-        provided, missing = (main_field, archive_field) if main_set else (archive_field, main_field)
-        raise ValueError(
-            f"{env_prefix}{provided.upper()} was overridden but {env_prefix}{missing.upper()} was left "
-            f"at its default. Set both explicitly (you may repeat the default value, but it must be explicit)."
-        )
 
 
 class Settings(BaseSettings):
@@ -101,14 +67,29 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_file=ENV_FILE, env_file_encoding="utf-8", env_prefix="PYLON_", extra="ignore")
 
+    # Pairs of (main, archive) network settings that must be overridden together.
+    _PAIRED_NETWORK_FIELDS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("bittensor_network", "bittensor_archive_network"),
+        ("evm_rpc_url", "evm_archive_rpc_url"),
+    )
+
     @model_validator(mode="after")
     def validate_networks_overridden_together(self) -> Self:
         """
         Reject overriding only one network of a main/archive pair, leaving its counterpart on the default.
+
+        Raises:
+            ValueError: If exactly one network of a pair was provided.
         """
-        _validate_paired_settings_overridden_together(
-            self.model_fields_set,
-            _PAIRED_NETWORK_FIELDS,
-            self.model_config.get("env_prefix", "") or "",
-        )
+        env_prefix = self.model_config.get("env_prefix", "") or ""
+        for main_field, archive_field in self._PAIRED_NETWORK_FIELDS:
+            main_set = main_field in self.model_fields_set
+            archive_set = archive_field in self.model_fields_set
+            if main_set == archive_set:
+                continue
+            provided, missing = (main_field, archive_field) if main_set else (archive_field, main_field)
+            raise ValueError(
+                f"{env_prefix}{provided.upper()} was overridden but {env_prefix}{missing.upper()} was left "
+                f"at its default. Set both explicitly (you may repeat the default value, but it must be explicit)."
+            )
         return self

--- a/pylon_commons/pylon_commons/settings.py
+++ b/pylon_commons/pylon_commons/settings.py
@@ -1,6 +1,8 @@
 import os
+from collections.abc import Iterable
+from typing import Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .types import (
@@ -11,6 +13,40 @@ from .types import (
 from .types import evm as evm_types
 
 ENV_FILE = os.environ.get("PYLON_ENV_FILE", ".env")
+
+# Pairs of (main, archive) network settings that must be overridden together.
+_PAIRED_NETWORK_FIELDS: tuple[tuple[str, str], ...] = (
+    ("bittensor_network", "bittensor_archive_network"),
+    ("evm_rpc_url", "evm_archive_rpc_url"),
+)
+
+
+def _validate_paired_settings_overridden_together(
+    fields_set: set[str],
+    field_pairs: Iterable[tuple[str, str]],
+    env_prefix: str,
+) -> None:
+    """
+    Ensure each main/archive network pair is either both left at its default or both set explicitly.
+
+    A pair with exactly one member provided is rejected, because silently mixing an overridden
+    network with a defaulted counterpart is an easy and dangerous misconfiguration. Repeating the
+    default value is allowed, as long as it is provided explicitly.
+
+    Raises:
+        ValueError: If exactly one member of a pair was provided.
+    """
+    for main_field, archive_field in field_pairs:
+        main_set = main_field in fields_set
+        archive_set = archive_field in fields_set
+        if main_set == archive_set:
+            continue
+        provided, missing = (main_field, archive_field) if main_set else (archive_field, main_field)
+        raise ValueError(
+            f"{env_prefix}{provided.upper()} was overridden but {env_prefix}{missing.upper()} was left "
+            f"at its default. When overriding one network you must set both explicitly (you may repeat "
+            f"the default value, but it must be explicit)."
+        )
 
 
 class Settings(BaseSettings):
@@ -65,3 +101,15 @@ class Settings(BaseSettings):
     debug: bool = False
 
     model_config = SettingsConfigDict(env_file=ENV_FILE, env_file_encoding="utf-8", env_prefix="PYLON_", extra="ignore")
+
+    @model_validator(mode="after")
+    def validate_networks_overridden_together(self) -> Self:
+        """
+        Reject overriding only one network of a main/archive pair, leaving its counterpart on the default.
+        """
+        _validate_paired_settings_overridden_together(
+            self.model_fields_set,
+            _PAIRED_NETWORK_FIELDS,
+            self.model_config.get("env_prefix", "") or "",
+        )
+        return self

--- a/pylon_commons/tests/test_settings.py
+++ b/pylon_commons/tests/test_settings.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from pylon_commons.settings import Settings
+
+
+@pytest.fixture(autouse=True)
+def clean_network_env(monkeypatch: pytest.MonkeyPatch):
+    for var in (
+        "PYLON_BITTENSOR_NETWORK",
+        "PYLON_BITTENSOR_ARCHIVE_NETWORK",
+        "PYLON_EVM_RPC_URL",
+        "PYLON_EVM_ARCHIVE_RPC_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def make_settings(**overrides: str) -> Settings:
+    return Settings(_env_file=None, **overrides)  # type: ignore
+
+
+def test_defaults_keep_default_networks():
+    settings = make_settings()
+
+    assert (settings.bittensor_network, settings.bittensor_archive_network) == ("finney", "archive")
+
+
+def test_both_bittensor_networks_overridden_together_pass():
+    settings = make_settings(
+        bittensor_network="ws://localhost:9944",
+        bittensor_archive_network="ws://archive:9944",
+    )
+
+    assert (settings.bittensor_network, settings.bittensor_archive_network) == (
+        "ws://localhost:9944",
+        "ws://archive:9944",
+    )
+
+
+def test_repeating_default_explicitly_passes():
+    settings = make_settings(
+        bittensor_network="finney",
+        bittensor_archive_network="archive",
+    )
+
+    assert (settings.bittensor_network, settings.bittensor_archive_network) == ("finney", "archive")
+
+
+def test_both_evm_urls_overridden_together_pass():
+    settings = make_settings(
+        evm_rpc_url="http://main:8545",
+        evm_archive_rpc_url="http://archive:8545",
+    )
+
+    assert (settings.evm_rpc_url, settings.evm_archive_rpc_url) == ("http://main:8545", "http://archive:8545")
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"bittensor_network": "ws://localhost:9944"}, id="only_bittensor_main"),
+        pytest.param({"bittensor_archive_network": "ws://archive:9944"}, id="only_bittensor_archive"),
+        pytest.param({"evm_rpc_url": "http://main:8545"}, id="only_evm_main"),
+        pytest.param({"evm_archive_rpc_url": "http://archive:8545"}, id="only_evm_archive"),
+    ],
+)
+def test_overriding_only_one_network_of_a_pair_raises(overrides: dict[str, str]):
+    with pytest.raises(ValidationError):
+        make_settings(**overrides)


### PR DESCRIPTION
Overriding one network of a main/archive pair (bittensor or evm) via env var while leaving its counterpart on the default is an easy, dangerous misconfiguration. Add a model validator that rejects setting exactly one member of a pair; both must be provided explicitly (repeating the default is allowed).

Impacts: service