### PR TITLE
fix: cap MaxBurn during bulk filler registration to avoid ReservesTooLow

### DIFF
--- a/pylon_service/tests/integration/client_service_e2e/test_set_commitment.py
+++ b/pylon_service/tests/integration/client_service_e2e/test_set_commitment.py
@@ -1,6 +1,6 @@
 import time
 
-from pylon_client.artanis import CommitmentDataHex
+from pylon_client.artanis import CommitmentDataHex, PylonNotFound
 from pylon_client.artanis.v1 import (
     GetCommitmentResponse,
     SetCommitmentResponse,
@@ -30,10 +30,15 @@ def test_set_revealed_commitment_writes_readable_revealed_commitment(pylon_clien
         assert set_response.reveal_round > 0
 
         commitment_set = None
-        for _ in range(8):
-            get_response = client.unstable.identity.get_own_revealed_commitments()
+        for _ in range(15):
+            try:
+                get_response = client.unstable.identity.get_own_revealed_commitments()
+            except PylonNotFound:
+                time.sleep(1)
+                continue
             commitment_set = next(
-                commitment for commitment in get_response.commitments if commitment.commitment == expected_commitment
+                (commitment for commitment in get_response.commitments if commitment.commitment == expected_commitment),
+                None,
             )
             if commitment_set is not None:
                 break

--- a/pylon_service/tests/integration/client_service_e2e/test_set_weights.py
+++ b/pylon_service/tests/integration/client_service_e2e/test_set_weights.py
@@ -49,14 +49,13 @@ async def test_set_weights(pylon_client_factory, low_weights_rate_limit, localch
             bob_uid = next(n.uid for n in neurons if n.hotkey == DevAccount.BOB.hotkey_ss58)
             alice_uid = next(n.uid for n in neurons if n.hotkey == DevAccount.ALICE.hotkey_ss58)
 
-            async with asyncio.timeout(30):
+            async with asyncio.timeout(90):
                 while True:
                     weights = await asyncio.shield(bt.subnet(2).weights.get(bob_uid))
-                    if weights:
+                    if alice_uid in weights:
                         break
                     await asyncio.sleep(1)
 
-            assert alice_uid in weights
             assert weights[alice_uid] == pytest.approx(1.0)
 
 
@@ -73,14 +72,13 @@ async def test_set_mechanism_weights(pylon_client_factory, low_weights_rate_limi
             bob_uid = next(n.uid for n in neurons if n.hotkey == DevAccount.BOB.hotkey_ss58)
             alice_uid = next(n.uid for n in neurons if n.hotkey == DevAccount.ALICE.hotkey_ss58)
 
-            async with asyncio.timeout(30):
+            async with asyncio.timeout(90):
                 while True:
                     weights = await asyncio.shield(bt.subnet(3).weights.get(bob_uid, mechanism_id=1))
-                    if weights:
+                    if alice_uid in weights:
                         break
                     await asyncio.sleep(1)
 
-            assert alice_uid in weights
             assert weights[alice_uid] == pytest.approx(1.0)
 
 
@@ -151,16 +149,15 @@ async def test_set_weights_succeeds_after_registration(
             alice_uid = next(n.uid for n in neurons if n.hotkey == DevAccount.ALICE.hotkey_ss58)
             logger.info("resolved_uids", charlie_uid=charlie_uid, alice_uid=alice_uid)
 
-            logger.info("waiting_for_weights_on_chain", timeout_seconds=60)
-            async with asyncio.timeout(60):
+            logger.info("waiting_for_weights_on_chain", timeout_seconds=180)
+            async with asyncio.timeout(180):
                 while True:
                     weights = await asyncio.shield(bt.subnet(NETUID_AFTER_REGISTRATION).weights.get(charlie_uid))
-                    if weights:
+                    if alice_uid in weights:
                         break
                     await asyncio.sleep(1)
 
             logger.info("weights_observed_on_chain", weights=weights)
-            assert alice_uid in weights
             assert weights[alice_uid] == pytest.approx(1.0)
 
     submit_frames = [f for f in ws_recorder.frames if is_expected_submit(f)]

--- a/pylon_service/tests/integration/localchain/README.md
+++ b/pylon_service/tests/integration/localchain/README.md
@@ -77,7 +77,7 @@ Four subnets are registered (owned by Alice):
 | Subnet 1 | 1 | 100 (default) | Read testing |
 | Subnet 2 | 2 | 50 (low) | Fast commit-reveal weight and write tests |
 | Subnet 3 | 3 | 50 (low) | Mechanism weight tests |
-| Subnet 4 | 4 | 50 (low) | Dedicated to `test_set_weights_succeeds_after_registration` — only Alice registered, `WeightsRateLimit=0`. **This test permanently mutates subnet 4 state** (registers Charlie, adds stake), so the subnet must remain single-tenant. |
+| Subnet 4 | 4 | 50 (low) | Dedicated to `test_set_weights_succeeds_after_registration` — only Alice registered, `WeightsRateLimit=0`, commit-reveal period 2 (see [Commit-Reveal Period on Subnet 4](#commit-reveal-period-on-subnet-4)). **This test permanently mutates subnet 4 state** (registers Charlie, adds stake), so the subnet must remain single-tenant. |
 
 Subtokens are enabled on all four subnets.
 
@@ -196,6 +196,22 @@ When writing such a test, prefer creating a **dedicated subnet** for it in
 `prepare_e2e_chain.py` (as was done for subnet 4, used exclusively by
 `test_set_weights_succeeds_after_registration`). Document the ownership in the
 *Subnets* table above so it stays a single-tenant subnet.
+
+### Commit-Reveal Period on Subnet 4
+
+Subnet 4 has its commit-reveal period (`RevealPeriodEpochs`) raised from the default 1 to **2**.
+
+The chain reveals a timelocked weight commit at the start of the first block of epoch
+`commit_epoch + reveal_period` — and this reveal runs **before** that block's epoch
+(`reveal_crv3_commits` precedes `run_coinbase` in `block_step`). Validator permits are only
+granted when a subnet epoch runs. `test_set_weights_succeeds_after_registration` registers
+Charlie, stakes, and commits weights all within one epoch, so with the default period of 1 the
+reveal fires exactly at the boundary where Charlie's permit is about to be granted — the permit
+does not exist yet, `do_set_mechanism_weights` fails `NeuronNoValidatorPermit`, and the chain
+**silently drops the commit** (the weights never appear, with no error surfaced anywhere).
+
+With a period of 2 the reveal happens one full epoch after the permit-granting epoch, so the
+commit reveals reliably.
 
 ### Drand Workaround
 

--- a/pylon_service/tests/integration/localchain/README.md
+++ b/pylon_service/tests/integration/localchain/README.md
@@ -176,7 +176,11 @@ Set on **subnet 2**only. Evm key associations for Alice and Charlie.
   call failures.
 - **Bulk registration tuning**: `MaxRegistrationsPerBlock` and `TargetRegistrationsPerInterval`
   are raised to 256, and `TxRateLimit` is set to 0 on e2e subnets 1 and 2 before filler
-  registration.
+  registration. `MaxBurn` is also capped just above the chain's `MaxBurnLowerBound` (0.1 TAO):
+  each burned registration swaps its burn from TAO into the subnet's alpha reserve, and the burn
+  ramps up (`BurnIncreaseMult`) after every registration, so an uncapped burn would drain the
+  alpha reserve below the swap pallet's `MinimumReserve` and make bulk registration fail with
+  `ReservesTooLow`.
 - **Drand.NextUnsignedAt**: Set to `current_block + 80` — see [Drand Workaround](#drand-workaround)
   below.
 

--- a/pylon_service/tests/integration/localchain/README.md
+++ b/pylon_service/tests/integration/localchain/README.md
@@ -234,12 +234,19 @@ await manager.offset_drand_next_unsigned_at()
 
 **Phase 2 — At container start time** (test fixtures):
 
-Immediately after starting the container, set `Drand.LastStoredRound` and
-`Drand.OldestStoredRound` to the **current real-world drand round** (fetched via
-`bittensor_drand.get_latest_round()`). This way, when the worker eventually starts (after the
-margin expires), it begins from the current round instead of the stale one.
+On the current localnet runtime the worker no longer catches up from a stale round on its own — it stalls
+after a single fetch batch — and if it wakes on the stale round it floods the chain with pulse extrinsics,
+which can starve the pin writes and deadlock. So `synchronize_drand_last_stored_round()` does, in order:
 
-Wait for the chain to catch up by waiting for the block number to exceed `Drand.NextUnsignedAt` set in phase 1. 
+1. **Hold** the worker asleep by pushing `Drand.NextUnsignedAt` far into the future — done *first*, while the
+   worker is still idle behind the phase 1 margin, so a slow `get_latest_round()` or storage write cannot lose
+   the race.
+2. **Pin** `Drand.LastStoredRound` and `Drand.OldestStoredRound` to the **current real-world drand round**
+   (fetched via `bittensor_drand.get_latest_round()`).
+3. **Wake** the worker by moving `Drand.NextUnsignedAt` back to a few blocks out; it now resumes from the
+   pinned current round instead of the stale one, without ever flooding.
+4. **Verify** the worker is actually tracking the current round, re-pinning as a safety net if the observed
+   gap is still large.
 
 ```python
 # In test conftest.py (simplified):

--- a/pylon_service/tests/integration/localchain/manager.py
+++ b/pylon_service/tests/integration/localchain/manager.py
@@ -506,6 +506,33 @@ class LocalChainManager:
             )
             await result.wait_for_finalization()
 
+    async def set_commit_reveal_period(self, netuid: int, reveal_period: int) -> None:
+        """
+        Set the commit-reveal period (in epochs) for a subnet via sudo call.
+
+        The chain reveals a timelocked weight commit at the start of the first block of epoch
+        ``commit_epoch + reveal_period``, BEFORE that block's epoch runs. Since validator permits
+        are only granted when an epoch runs, a neuron that registers and commits within the same
+        epoch needs ``reveal_period >= 2`` for its permit to exist by reveal time — with the
+        default of 1 the reveal fails permit validation and the commit is silently dropped.
+
+        Args:
+            netuid: Subnet UID.
+            reveal_period: Number of epochs between a weight commit and its reveal.
+        """
+        logger.info("Setting commit reveal period to %d on subnet %d", reveal_period, netuid)
+        async with self._turbobt_client() as client:
+            result = await client.subtensor.sudo.sudo(
+                "AdminUtils",
+                "sudo_set_commit_reveal_weights_interval",
+                {
+                    "netuid": netuid,
+                    "interval": reveal_period,
+                },
+                wallet=SUDO_WALLET,
+            )
+            await result.wait_for_finalization()
+
     async def _set_next_unsigned_at(self, block_number: int) -> None:
         """
         Set the block at which the drand offchain worker resumes fetching pulses.

--- a/pylon_service/tests/integration/localchain/manager.py
+++ b/pylon_service/tests/integration/localchain/manager.py
@@ -611,6 +611,31 @@ class LocalChainManager:
             params=[netuid],
         )
 
+    async def set_max_burn(self, netuid: int, max_burn_rao: int) -> None:
+        """
+        Cap the maximum registration burn for a subnet via sudo call.
+
+        Each burned registration swaps the burn cost from TAO into the subnet's
+        alpha reserve, and the burn ramps up (BurnIncreaseMult) after every
+        registration. Left unbounded, bulk registration drains the alpha reserve
+        below the swap pallet's MinimumReserve and fails with ReservesTooLow.
+        Capping the burn low keeps each swap tiny so the reserve stays healthy.
+
+        Args:
+            netuid: Subnet UID.
+            max_burn_rao: Maximum burn in RAO. Must exceed the chain's
+                MaxBurnLowerBound (0.1 TAO).
+        """
+        logger.info("Setting max burn to %d on subnet %d", max_burn_rao, netuid)
+        async with self._turbobt_client() as client:
+            result = await client.subtensor.sudo.sudo(
+                "AdminUtils",
+                "sudo_set_max_burn",
+                {"netuid": netuid, "max_burn": max_burn_rao},
+                wallet=SUDO_WALLET,
+            )
+            await result.wait_for_finalization()
+
     async def set_serving_rate_limit(self, netuid: int, rate_limit: int) -> None:
         """
         Set the serving rate limit for a subnet via sudo storage update.

--- a/pylon_service/tests/integration/localchain/manager.py
+++ b/pylon_service/tests/integration/localchain/manager.py
@@ -40,7 +40,13 @@ _CONTACT_TEST_AXON_PORT = 12345
 
 _RAO_PER_TAO = 1_000_000_000
 
-_DRAND_WORKER_MARGIN = 80  # Roughly after how many blocks after starting the chain drand rounds will start fetching
+_DRAND_WORKER_MARGIN = 600  # Blocks the worker stays idle after container start, so phase 2 can pin before it wakes
+_DRAND_MAX_ACCEPTABLE_GAP = (
+    60  # How many rounds the worker may lag behind the current real drand round to count as synced
+)
+_DRAND_SYNC_MAX_ATTEMPTS = 90  # Per-phase polling cap (seconds) while synchronizing the drand worker
+_DRAND_SYNC_HOLD_MARGIN = 600  # Blocks to keep the worker asleep while phase 2 pins the current round
+_DRAND_WAKE_DELAY = 5  # Blocks after pinning before the worker is woken to resume fetching
 
 
 class ChainStorage(enum.StrEnum):
@@ -500,26 +506,28 @@ class LocalChainManager:
             )
             await result.wait_for_finalization()
 
-    async def offset_drand_next_unsigned_at(self):
+    async def _set_next_unsigned_at(self, block_number: int) -> None:
         """
-        Phase 1 of drand workaround — see localchain/README.md#drand-workaround
+        Set the block at which the drand offchain worker resumes fetching pulses.
         """
-        current_block = await self.get_current_block_number()
-        block_number = current_block + _DRAND_WORKER_MARGIN
-
         logger.info("Setting Drand.NextUnsignedAt to %d", block_number)
         await self._set_storage(
             storage=ChainStorage.DRAND_NEXT_UNSIGNED_AT,
             storage_value=f"0x{block_number.to_bytes(4, byteorder='little', signed=False).hex()}",
         )
 
-    async def synchronize_drand_last_stored_round(self) -> None:
+    async def offset_drand_next_unsigned_at(self):
         """
-        Phase 2 of drand workaround — see localchain/README.md#drand-workaround
+        Phase 1 of drand workaround — see localchain/README.md#drand-workaround
         """
-        latest_round = bittensor_drand.get_latest_round()
-        round_number = latest_round - 1
+        current_block = await self.get_current_block_number()
+        await self._set_next_unsigned_at(current_block + _DRAND_WORKER_MARGIN)
 
+    async def _reset_drand_stored_round(self, round_number: int) -> None:
+        """
+        Point the drand offchain worker at ``round_number`` by overwriting
+        Drand.LastStoredRound and Drand.OldestStoredRound.
+        """
         logger.info("Setting Drand.LastStoredRound to %d", round_number)
         await self._set_storage(
             storage=ChainStorage.DRAND_LAST_STORED_ROUND,
@@ -532,13 +540,48 @@ class LocalChainManager:
             storage_value=f"0x{round_number.to_bytes(8, byteorder='little', signed=False).hex()}",
         )
 
-        drand_next_unsigned_at = cast(int, await self.get_storage(ChainStorage.DRAND_NEXT_UNSIGNED_AT))
-        print(f"Waiting for block to reach current Drand.NextUnsignedAt: {drand_next_unsigned_at}")
-        for _ in range(30):
-            block = await self.get_current_block_number()
-            if block >= drand_next_unsigned_at:
+    async def synchronize_drand_last_stored_round(self) -> None:
+        """
+        Phase 2 of drand workaround — see localchain/README.md#drand-workaround.
+
+        On the current localnet runtime the worker no longer catches up from a stale snapshot
+        round on its own — it stalls after a single batch — and if it wakes on the stale round it
+        floods the chain with pulse extrinsics, which can starve the pin writes and deadlock. So
+        this first pushes the worker's wake block far out (while it is still idle behind the phase 1
+        margin), pins the stored round to the current real drand round, wakes the worker again, and
+        only then verifies it is tracking the current round, re-pinning as a safety net.
+
+        Raises:
+            RuntimeError: If the worker never starts tracking the current round.
+        """
+        current_block = await self.get_current_block_number()
+        await self._set_next_unsigned_at(current_block + _DRAND_SYNC_HOLD_MARGIN)
+
+        pinned_round = bittensor_drand.get_latest_round() - 1
+        await self._reset_drand_stored_round(pinned_round)
+
+        wake_block = (await self.get_current_block_number()) + _DRAND_WAKE_DELAY
+        await self._set_next_unsigned_at(wake_block)
+        logger.info("Waiting for block to reach Drand.NextUnsignedAt: %d", wake_block)
+        for _ in range(_DRAND_SYNC_MAX_ATTEMPTS):
+            if (await self.get_current_block_number()) >= wake_block:
                 break
             await asyncio.sleep(1)
+
+        for _ in range(_DRAND_SYNC_MAX_ATTEMPTS):
+            latest_round = bittensor_drand.get_latest_round()
+            stored_round = cast(int, await self.get_storage(ChainStorage.DRAND_LAST_STORED_ROUND))
+            gap = latest_round - stored_round
+            if gap > _DRAND_MAX_ACCEPTABLE_GAP:
+                logger.warning("Drand worker woke on a stale round (%d behind); re-pinning to current", gap)
+                pinned_round = latest_round - 1
+                await self._reset_drand_stored_round(pinned_round)
+            elif stored_round > pinned_round:
+                logger.info("Drand worker is tracking the current round (stored %d)", stored_round)
+                return
+            await asyncio.sleep(1)
+
+        raise RuntimeError("Drand worker did not start tracking the current round in time")
 
     async def set_tempo(self, netuid: int, tempo: int) -> None:
         """

--- a/pylon_service/tests/integration/localchain/prepare_e2e_chain.py
+++ b/pylon_service/tests/integration/localchain/prepare_e2e_chain.py
@@ -75,6 +75,7 @@ FILLER_NEURON_COUNT = MAX_NEURONS - len(DevAccount) - 1  # 251 (UID 0 is a pre-e
 FILLER_TRANSFER_AMOUNT_TAO = 500
 FILLER_REGISTRATION_BATCH_SIZE = 64
 FILLER_TRANSFER_BATCH_SIZE = 256
+FILLER_REGISTRATION_MAX_BURN_RAO = 100_000_001
 
 
 def create_filler_wallets(count: int, wallet_dir: str) -> list[Wallet]:
@@ -178,6 +179,7 @@ async def main() -> None:
             await manager.set_max_registrations_per_block(netuid=netuid, max_regs=256)
             await manager.set_target_registrations_per_interval(netuid=netuid, target=256)
             await manager.set_tx_rate_limit(netuid=netuid, rate_limit=0)
+            await manager.set_max_burn(netuid=netuid, max_burn_rao=FILLER_REGISTRATION_MAX_BURN_RAO)
 
         log_step(f"Creating {FILLER_NEURON_COUNT} filler wallets")
         with tempfile.TemporaryDirectory(prefix="filler-wallets-") as tmpdir:

--- a/pylon_service/tests/integration/localchain/prepare_e2e_chain.py
+++ b/pylon_service/tests/integration/localchain/prepare_e2e_chain.py
@@ -37,7 +37,9 @@ Preparation steps (in order):
     9.  Set commitments for Charlie and Dave on subnet 1
     10. Create & fund 251 filler wallets
     11. Register 251 filler neurons on subnets 1 and 2 (parallelized)
-    12. Create subnet 4; register only Alice; set low tempo and weights_rate_limit=0
+    12. Create subnet 4; register only Alice; set low tempo, weights_rate_limit=0
+        and commit-reveal period 2 (so a permit granted by the first epoch after
+        in-test registration exists by reveal time)
     13. Set Drand.NextUnsignedAt (MUST be last before snapshot)
     14. Create Docker snapshot
 """
@@ -68,6 +70,7 @@ LOW_TEMPO_NETUIDS = [2, 3]
 MECHANISMS_NETUID = 3
 REGISTRATION_RETRY_NETUID = 4
 REGISTRATION_RETRY_TEMPO = LOW_TEMPO
+REGISTRATION_RETRY_REVEAL_PERIOD = 2
 
 MAX_NEURONS = 256
 FILLER_NEURONS_NETUIDS = [1, 2]
@@ -212,6 +215,9 @@ async def main() -> None:
         await manager.register_neuron(wallet=alice.wallet, netuid=REGISTRATION_RETRY_NETUID)
         await manager.set_tempo(netuid=REGISTRATION_RETRY_NETUID, tempo=REGISTRATION_RETRY_TEMPO)
         await manager.set_weights_rate_limit(netuid=REGISTRATION_RETRY_NETUID, rate_limit=0)
+        await manager.set_commit_reveal_period(
+            netuid=REGISTRATION_RETRY_NETUID, reveal_period=REGISTRATION_RETRY_REVEAL_PERIOD
+        )
 
         # Phase 1 of drand workaround — see localchain/README.md#drand-workaround
         log_step("Setting Drand.NextUnsignedAt")


### PR DESCRIPTION
The e2e localchain snapshot seeds off the moving subtensor-localnet:main tag. A subtensor runtime change made each burned registration swap its burn from TAO into the subnet's alpha reserve, with the burn ramping geometrically (BurnIncreaseMult) after every registration. Registering 251 filler neurons drained SubnetAlphaIn below the swap pallet's MinimumReserve, so the prepare script failed with ReservesTooLow partway through bulk registration.

Cap MaxBurn just above the chain's MaxBurnLowerBound (0.1 TAO) on the filler subnets before bulk registration so each swap stays tiny and the alpha reserve stays healthy.