### PR TITLE
Added explicit error for missing methods in old blocks

### DIFF
--- a/pylon_service/pylon_service/api/utils.py
+++ b/pylon_service/pylon_service/api/utils.py
@@ -17,7 +17,7 @@ from pylon_service.api.services import (
     RecentObjectMissingError,
     RecentObjectStaleError,
 )
-from pylon_service.bittensor.exceptions import BittensorTransportError
+from pylon_service.bittensor.exceptions import BittensorTransportError, RuntimeApiUnavailableException
 from pylon_service.evm.exceptions import EvmInvalidAbiError, EvmInvalidAddressError, EvmRpcError
 from pylon_service.identities import identities
 
@@ -34,6 +34,9 @@ def _response_for_exception(exc: Exception) -> Response | None:
 
     if isinstance(exc, BittensorTransportError):
         return Response(status_code=502, content={"status_code": 502, "detail": exc.detail})
+
+    if isinstance(exc, RuntimeApiUnavailableException):
+        return Response(status_code=501, content={"status_code": 501, "detail": exc.detail})
 
     if isinstance(exc, EvmInvalidAddressError):
         return Response(status_code=400, content={"status_code": 400, "detail": exc.detail})

--- a/pylon_service/pylon_service/bittensor/contact_router.py
+++ b/pylon_service/pylon_service/bittensor/contact_router.py
@@ -20,7 +20,12 @@ from pylon_commons.types import (
 from turbobt.substrate.exceptions import SubstrateException, UnknownBlock
 
 from pylon_service.bittensor.contact import AbstractBittensorContact
-from pylon_service.bittensor.exceptions import ArchiveFallbackException, ArchiveInvalidParamsException
+from pylon_service.bittensor.exceptions import (
+    ArchiveFallbackException,
+    ArchiveInvalidParamsException,
+    RuntimeApiUnavailableException,
+    is_missing_runtime_method,
+)
 from pylon_service.bittensor.models import (
     Block,
     CertificateAlgorithm,
@@ -99,6 +104,8 @@ class BittensorContactRouter:
                 try:
                     return await archive_call()
                 except UnknownBlock as exc:
+                    if is_missing_runtime_method(exc):
+                        raise self._runtime_api_unavailable(operation_name, block, exc) from exc
                     raise ArchiveFallbackException(
                         detail=(
                             f"Block {block.number} data is unavailable on the archive node. "
@@ -134,6 +141,8 @@ class BittensorContactRouter:
             try:
                 return await archive_call()
             except UnknownBlock as archive_exc:
+                if is_missing_runtime_method(archive_exc):
+                    raise self._runtime_api_unavailable(operation_name, block, archive_exc) from archive_exc
                 raise ArchiveFallbackException(
                     detail=f"Block {block.number} data is unavailable on both main and archive nodes."
                 ) from archive_exc
@@ -147,6 +156,17 @@ class BittensorContactRouter:
                         )
                     ) from exc
                 raise
+
+    @staticmethod
+    def _runtime_api_unavailable(
+        operation_name: str, block: Block, exc: BaseException
+    ) -> RuntimeApiUnavailableException:
+        return RuntimeApiUnavailableException(
+            detail=(
+                f"The runtime API required for '{operation_name}' is not available at block {block.number}. "
+                f"It was introduced by a later runtime upgrade, so older blocks do not export it ({exc})."
+            )
+        )
 
     async def get_block(self, number):
         return await self._delegate(

--- a/pylon_service/pylon_service/bittensor/exceptions.py
+++ b/pylon_service/pylon_service/bittensor/exceptions.py
@@ -39,3 +39,25 @@ class SubnetStateUnavailable(BittensorException):
     """
     Raised when subnet state is not available for a given netuid and block.
     """
+
+
+class RuntimeApiUnavailableException(BittensorException):
+    """
+    Raised when a runtime API method is not exported at the requested block.
+
+    Subtensor returns RPC error code 4003 both for a genuinely unknown/pruned block and for a runtime
+    method that a later runtime upgrade introduced (e.g. SwapRuntimeApi.current_alpha_price_all does not
+    exist before block ~7782857). turbobt surfaces both as UnknownBlock, so we disambiguate on the message
+    and raise this instead of the misleading ArchiveFallbackException ("block data is unavailable").
+    """
+
+
+def is_missing_runtime_method(exc: BaseException) -> bool:
+    """
+    Detect Subtensor's "Exported method ... is not found" error.
+
+    turbobt maps every RPC error with code 4003 to UnknownBlock, conflating a missing runtime method with
+    a genuinely unknown block. The distinguishing signal is only in the message text.
+    """
+    message = str(exc)
+    return "Exported method" in message and "is not found" in message

--- a/pylon_service/tests/unit/bittensor/test_contact_router.py
+++ b/pylon_service/tests/unit/bittensor/test_contact_router.py
@@ -32,7 +32,7 @@ from pylon_commons.types import (
 from turbobt.substrate.exceptions import UnknownBlock
 
 from pylon_service.bittensor.contact_router import BittensorContactRouter
-from pylon_service.bittensor.exceptions import ArchiveFallbackException
+from pylon_service.bittensor.exceptions import ArchiveFallbackException, RuntimeApiUnavailableException
 from pylon_service.bittensor.mock_contact import MockBittensorContact
 
 
@@ -148,3 +148,50 @@ async def test_contact_router_unknown_block_on_both_nodes_raises_archive_fallbac
         ):
             with pytest.raises(ArchiveFallbackException, match="unavailable on both main and archive nodes"):
                 await contact_router.get_neurons_list(netuid=NetUid(1), block=recent_block)
+
+
+@pytest.mark.asyncio
+async def test_contact_router_missing_runtime_method_on_stale_block_raises_runtime_api_unavailable(
+    contact_router, main_contact, archive_contact
+):
+    """
+    A 4003 'Exported method ... is not found' from the archive must surface as an honest
+    RuntimeApiUnavailableException, not the misleading 'block data is unavailable' message.
+    """
+    stale_block = Block(number=BlockNumber(100), hash=BlockHash("0xstale"))
+    latest_block = Block(number=BlockNumber(500), hash=BlockHash("0xlatest"))
+
+    async with contact_router:
+        async with (
+            main_contact.mock_behavior(get_latest_block=[latest_block]),
+            archive_contact.mock_behavior(
+                get_alpha_prices=[
+                    UnknownBlock(
+                        "Client error: Execution failed: Other: Exported method SwapRuntimeApi_current_alpha_price_all is not found"
+                    )
+                ]
+            ),
+        ):
+            with pytest.raises(RuntimeApiUnavailableException, match="not available at block 100"):
+                await contact_router.get_alpha_prices(stale_block)
+
+
+@pytest.mark.asyncio
+async def test_contact_router_genuine_unknown_block_on_stale_block_raises_archive_fallback(
+    contact_router, main_contact, archive_contact
+):
+    """
+    A genuine unknown/pruned block (no 'Exported method' signature) keeps the archive-unavailable message.
+    """
+    stale_block = Block(number=BlockNumber(100), hash=BlockHash("0xstale"))
+    latest_block = Block(number=BlockNumber(500), hash=BlockHash("0xlatest"))
+
+    async with contact_router:
+        async with (
+            main_contact.mock_behavior(get_latest_block=[latest_block]),
+            archive_contact.mock_behavior(
+                get_alpha_prices=[UnknownBlock("Api called for an unknown Block: State already discarded")]
+            ),
+        ):
+            with pytest.raises(ArchiveFallbackException, match="unavailable on the archive node"):
+                await contact_router.get_alpha_prices(stale_block)


### PR DESCRIPTION
Subtensor returns RPC error code 4003 both for a genuinely unknown/pruned block and for a runtime method that a later runtime upgrade introduced (e.g. SwapRuntimeApi.current_alpha_price_all does not exist before block ~7782857). turbobt surfaces both as UnknownBlock.

This PR is a just a cosmetic fix that raises a more explicit error in the server when the method is missing versus when the block is missing.