### PR TITLE
fix: reconnect on TypeError so a poisoned turbobt client self-recovers

### DIFF
--- a/pylon_service/pylon_service/bittensor/contact.py
+++ b/pylon_service/pylon_service/bittensor/contact.py
@@ -84,7 +84,7 @@ from pylon_service.metrics import Attr, Param, bittensor_operation_duration, tra
 logger = structlog.stdlib.get_logger(__name__)
 
 unknown_hotkey = Hotkey("N/A")
-RECONNECT_EXCEPTIONS = (AttributeError, ConnectionClosed, OSError, RuntimeError)
+RECONNECT_EXCEPTIONS = (AttributeError, ConnectionClosed, OSError, RuntimeError, TypeError)
 
 
 class BittensorPort(Protocol):


### PR DESCRIPTION
A transient failure during turbobt runtime init can leave the client
half-initialized (_registry set, _apis None). Every later call then raises
TypeError: 'NoneType' object is not subscriptable, and _protect_turbobt
never triggers _recreate_bt_client() because TypeError is not in
RECONNECT_EXCEPTIONS — the contact stays broken for the life of the process.

Observed in production on mainnet 2026-07-27/28 after the spec 439/440
runtime upgrades: HTTP 500 on all neuron/weight requests for hours; only a
container restart cleared it. AttributeError (the sibling failure shape) is
already in the list.

impacts: service