### PR TITLE
fix: harden turbobt transport recovery

### DIFF
--- a/pylon_service/pylon_service/bittensor/contact.py
+++ b/pylon_service/pylon_service/bittensor/contact.py
@@ -79,12 +79,25 @@ from pylon_service.bittensor.models import (
     SubnetState,
 )
 from pylon_service.bittensor.utils import map_to_commitment, map_to_revealed_commitment
-from pylon_service.metrics import Attr, Param, bittensor_operation_duration, track_operation
+from pylon_service.metrics import (
+    Attr,
+    Param,
+    bittensor_operation_duration,
+    bittensor_transport_recovery_total,
+    track_operation,
+)
 
 logger = structlog.stdlib.get_logger(__name__)
 
 unknown_hotkey = Hotkey("N/A")
 RECONNECT_EXCEPTIONS = (AttributeError, ConnectionClosed, OSError, RuntimeError)
+RECOVERABLE_ATTRIBUTE_ERROR_MESSAGES = frozenset({"'str' object has no attribute 'hex'"})
+
+
+def _is_recoverable_transport_error(exc: BaseException) -> bool:
+    if isinstance(exc, AttributeError):
+        return str(exc) in RECOVERABLE_ATTRIBUTE_ERROR_MESSAGES
+    return isinstance(exc, (ConnectionClosed, OSError, RuntimeError))
 
 
 class BittensorPort(Protocol):
@@ -370,6 +383,14 @@ class TurboBtContact(AbstractBittensorContact):
                 )
             raise cancelled_error from None
         except RECONNECT_EXCEPTIONS as exc:
+            if not _is_recoverable_transport_error(exc):
+                raise
+            error_type = type(exc).__name__
+            bittensor_transport_recovery_total.labels(
+                operation=operation_name,
+                outcome="attempted",
+                error_type=error_type,
+            ).inc()
             logger.info(
                 "recoverable_transport_error",
                 operation=operation_name,
@@ -379,12 +400,50 @@ class TurboBtContact(AbstractBittensorContact):
             try:
                 await asyncio.shield(self._recreate_bt_client())
             except Exception as recreate_exc:
+                bittensor_transport_recovery_total.labels(
+                    operation=operation_name,
+                    outcome="failed",
+                    error_type=error_type,
+                ).inc()
+                logger.warning(
+                    "bittensor_transport_recovery_failed",
+                    operation=operation_name,
+                    uri=self.uri,
+                    error=self._transport_gist(recreate_exc),
+                    phase="recreate",
+                )
                 raise self._transport_error(operation_name, recreate_exc) from recreate_exc
             bt_client = await self._get_bt_client()
             try:
-                return await asyncio.shield(coro_factory(bt_client))
+                result = await asyncio.shield(coro_factory(bt_client))
             except RECONNECT_EXCEPTIONS as retry_exc:
+                if not _is_recoverable_transport_error(retry_exc):
+                    raise
+                bittensor_transport_recovery_total.labels(
+                    operation=operation_name,
+                    outcome="failed",
+                    error_type=error_type,
+                ).inc()
+                logger.warning(
+                    "bittensor_transport_recovery_failed",
+                    operation=operation_name,
+                    uri=self.uri,
+                    error=self._transport_gist(retry_exc),
+                    phase="retry",
+                )
                 raise self._transport_error(operation_name, retry_exc) from retry_exc
+            bittensor_transport_recovery_total.labels(
+                operation=operation_name,
+                outcome="succeeded",
+                error_type=error_type,
+            ).inc()
+            logger.info(
+                "bittensor_transport_recovery_succeeded",
+                operation=operation_name,
+                uri=self.uri,
+                error_type=error_type,
+            )
+            return result
 
     def _resolve_hotkey(self, hotkey: Hotkey | None) -> Hotkey:
         if hotkey:

--- a/pylon_service/pylon_service/metrics.py
+++ b/pylon_service/pylon_service/metrics.py
@@ -168,6 +168,18 @@ bittensor_fallback_total = Counter(
     ["reason", "operation", "hotkey"],
 )
 
+bittensor_transport_recovery_total = Counter(
+    "pylon_bittensor_transport_recovery_total",
+    """Total number of Bittensor transport recovery outcomes.
+
+    Labels:
+        operation: Name of the Bittensor operation that encountered the failure.
+        outcome: Recovery lifecycle outcome ("attempted", "succeeded", or "failed").
+        error_type: Exception type that triggered the recovery attempt.
+    """,
+    ["operation", "outcome", "error_type"],
+)
+
 # ApplyWeights metrics
 apply_weights_job_duration = Histogram(
     "pylon_apply_weights_job_duration_seconds",

--- a/pylon_service/tests/unit/bittensor/contact/test_turbobt_contact.py
+++ b/pylon_service/tests/unit/bittensor/contact/test_turbobt_contact.py
@@ -15,6 +15,7 @@ from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from pylon_service.bittensor.contact import TurboBtContact
 from pylon_service.bittensor.exceptions import BittensorTransportError
+from pylon_service.metrics import bittensor_transport_recovery_total
 
 
 @pytest.fixture
@@ -165,10 +166,62 @@ async def test_runtime_error_triggers_contact_recreation_and_retry_without_trace
     assert len(reconnect_records) == 1
     assert reconnect_records[0].levelno == logging.INFO
     assert reconnect_records[0].exc_info is None
+    recovery_records = [
+        record
+        for record in records
+        if (event := cast(dict[str, Any], record.msg))["event"] == "bittensor_transport_recovery_succeeded"
+        and event["operation"] == "get_block"
+    ]
+    assert len(recovery_records) == 1
     assert block_ref.get.call_count == 1
     assert new_block_ref.get.call_count == 1
     old_raw_client.__aexit__.assert_called_once()
     assert bittensor_ctor.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_known_hex_attribute_error_triggers_contact_recreation_and_records_recovery(
+    open_contact, bittensor_ctor, raw_client, block_ref
+):
+    block_ref.get.side_effect = AttributeError("'str' object has no attribute 'hex'")
+
+    new_raw_client = create_autospec(Bittensor, instance=True)
+    new_raw_client.__aenter__ = AsyncMock(return_value=new_raw_client)
+    new_raw_client.__aexit__ = AsyncMock(return_value=None)
+    new_block_ref = create_autospec(TurboBtBlockReference, instance=True)
+    new_block_ref.get.return_value = TurboBtBlock("hash", 42, client=new_raw_client)
+    new_raw_client.block.return_value = new_block_ref
+    bittensor_ctor.side_effect = [new_raw_client]
+
+    attempted = bittensor_transport_recovery_total.labels(
+        operation="get_block", outcome="attempted", error_type="AttributeError"
+    )
+    succeeded = bittensor_transport_recovery_total.labels(
+        operation="get_block", outcome="succeeded", error_type="AttributeError"
+    )
+    attempted_before = attempted._value.get()
+    succeeded_before = succeeded._value.get()
+
+    result = await open_contact.get_block(BlockNumber(42))
+
+    assert result == Block(number=BlockNumber(42), hash=BlockHash("hash"))
+    assert attempted._value.get() == attempted_before + 1
+    assert succeeded._value.get() == succeeded_before + 1
+    raw_client.__aexit__.assert_called_once()
+    assert bittensor_ctor.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_unrelated_attribute_error_propagates_without_recreation(
+    open_contact, bittensor_ctor, raw_client, block_ref
+):
+    block_ref.get.side_effect = AttributeError("programming bug")
+
+    with pytest.raises(AttributeError, match="programming bug"):
+        await open_contact.get_block(BlockNumber(42))
+
+    raw_client.__aexit__.assert_not_called()
+    assert bittensor_ctor.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -236,14 +289,29 @@ async def test_runtime_error_on_retry_raises_bittensor_transport_error(open_cont
     bittensor_ctor.side_effect = [new_raw_client]
     block_ref.get.side_effect = RuntimeError("turbobt broken permanently")
 
-    with pytest.raises(
-        BittensorTransportError,
-        match="get_block failed on mock://test: RuntimeError: turbobt broken permanently",
-    ) as exc_info:
-        await open_contact.get_block(BlockNumber(42))
+    failed = bittensor_transport_recovery_total.labels(
+        operation="get_block", outcome="failed", error_type="RuntimeError"
+    )
+    failed_before = failed._value.get()
+
+    with capture_contact_logs() as records:
+        with pytest.raises(
+            BittensorTransportError,
+            match="get_block failed on mock://test: RuntimeError: turbobt broken permanently",
+        ) as exc_info:
+            await open_contact.get_block(BlockNumber(42))
 
     assert block_ref.get.call_count == 1
     assert new_block_ref.get.call_count == 1
+    assert failed._value.get() == failed_before + 1
+    failure_records = [
+        record
+        for record in records
+        if (event := cast(dict[str, Any], record.msg))["event"] == "bittensor_transport_recovery_failed"
+        and event["operation"] == "get_block"
+        and event["phase"] == "retry"
+    ]
+    assert len(failure_records) == 1
     assert exc_info.value.operation == "get_block"
     assert exc_info.value.uri == "mock://test"
     assert exc_info.value.error_type == "RuntimeError"


### PR DESCRIPTION
## Summary

- recover from the observed TurboBT `AttributeError: 'str' object has no attribute 'hex'` transport failure by recreating the contact and retrying once
- keep unrelated `AttributeError`s visible instead of masking programming defects as reconnects
- expose attempted, succeeded, and failed recovery outcomes through a bounded Prometheus counter and structured success/failure logs

This is orthogonal to #99: that PR adds `TypeError` to client recreation, while this change narrows the existing `AttributeError` handling to the production failure signature and makes its recovery observable.

## Validation

- `PYLON_ENV_FILE=tests/.test-env PYTHONWARNINGS=ignore uv run --python 3.13 pytest -q tests/unit/bittensor/contact/test_turbobt_contact.py` (10 passed)
- `uv run --python 3.13 ruff format --check pylon_service/bittensor/contact.py pylon_service/metrics.py tests/unit/bittensor/contact/test_turbobt_contact.py`
- `uv run --python 3.13 ruff check pylon_service/bittensor/contact.py pylon_service/metrics.py tests/unit/bittensor/contact/test_turbobt_contact.py`

The unscoped local `tests/unit` invocation requires optional runtime dependencies (notably `greenlet`) that are provisioned by the repository's CI/nox environment; the focused contact suite and changed-file lint checks pass locally.

Impacts: service
